### PR TITLE
Using hooks to deal with Tapable.plugin deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,26 @@ function apply(compiler) {
 
   options.output.libraryTarget = 'amd'; // the plugin is compatible with amd only
 
-  compiler.plugin('compilation', function (compilation) {
-    compilation.plugin('optimize-chunk-assets', function (chunks, done) {
+  if (compiler.hooks) {
+    const plugin = { name: 'WPAsyncDefine' };
+    compiler.hooks.compilation.tap(plugin, function (compilation) {
+      compilation.hooks.optimizeChunkAssets.tap(plugin, onOptimizeChunkAssets(compilation));
+    });
+  } else {
+    compiler.plugin('compilation', function (compilation) {
+      compilation.plugin('optimize-chunk-assets', onOptimizeChunkAssets(compilation))
+    });
+  }
+
+  function onOptimizeChunkAssets(compilation) {
+    function optimizeChunkAssets (chunks, done) {
       wrapChunks(compilation, chunks);
-      done();
-    })
-  });
+      if (done) {
+        done();
+      }
+    }
+    return optimizeChunkAssets;
+  }
 
   function wrapFile(compilation, fileName) {
     console.log('FileName', fileName);


### PR DESCRIPTION
This PR deals with the warning 
```
(node:46278) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead`
```
 that has started showing in some of our projects after upgrading to Webpack 4 . 
A solution to this problem has been proposed in https://github.com/webpack/webpack/issues/6568#issuecomment-373068943

I also had a look at how it is implemented in [uglifyjs-webpack-plugin](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/blob/c67566ef8baf0aed59007f6d2324bf84e8605c39/src/index.js#L331-L350)

